### PR TITLE
chore: :pushpin: set node 18 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "start": "next start",
     "lint": "next lint"
   },
+  "engines": {
+    "node": "^18"
+  },
   "dependencies": {
     "@solana/pay": "^0.2.0",
     "@solana/wallet-adapter-base": "^0.9.4",


### PR DESCRIPTION
Set node 18 in the package.json as required version to avoid compilation errors